### PR TITLE
Specify application/octet-stream when uploading for bundle edition

### DIFF
--- a/main.go
+++ b/main.go
@@ -301,7 +301,7 @@ func main() {
 				}
 				editsExpansionfilesService := androidpublisher.NewEditsExpansionfilesService(service)
 				editsExpansionfilesCall := editsExpansionfilesService.Upload(configs.PackageName, appEdit.Id, versionCode, expfileType)
-				editsExpansionfilesCall.Media(expansionFile, googleapi.ContentType("application/vnd.android.package-archive"))
+				editsExpansionfilesCall.Media(expansionFile, googleapi.ContentType("application/octet-stream"))
 				if _, err := editsExpansionfilesCall.Do(); err != nil {
 					failf("Failed to upload expansion file, error: %s", err)
 				}


### PR DESCRIPTION
Edits.bundles: upload  |  Google Play Developer API  |  Google Developers
https://developers.google.com/android-publisher/api-ref/edits/bundles/upload
> This method supports an /upload URI and accepts uploaded media with the following characteristics:
>
>     Maximum file size: 2GB
>     Accepted Media MIME types: application/octet-stream