### PR TITLE
Tool 54 ci fix

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -128,7 +128,7 @@ workflows:
     # google play deploy
     - PACKAGE_NAME: "io.bitrise.realmtasks"
     - BITRISEIO_JSON_KEY_URL: $BITRISEIO_JSON_KEY_URL
-    - TRACK: "beta"
+    - TRACK: "production"
     before_run:
       - _common_apk
     steps:
@@ -150,7 +150,7 @@ workflows:
       # google play deploy
       - PACKAGE_NAME: "io.bitrise.realmtasks"
       - BITRISEIO_JSON_KEY_URL: $BITRISEIO_JSON_KEY_URL
-      - TRACK: "alpha"
+      - TRACK: "beta"
     before_run:
       - _common_apk
     steps:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -11,9 +11,10 @@ workflows:
     - golint:
     - errcheck:
     - go-test:
+    # apk deploy is before aab deploy otherwise AAB owerrides APKs when app_path input is read
     after_run:
-    - aab_deploy_test
     - apk_deploy_test_1
+    - aab_deploy_test
 
   ci_untrack_phase2:
     after_run:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -128,7 +128,7 @@ workflows:
     # google play deploy
     - PACKAGE_NAME: "io.bitrise.realmtasks"
     - BITRISEIO_JSON_KEY_URL: $BITRISEIO_JSON_KEY_URL
-    - TRACK: "production"
+    - TRACK: "beta"
     before_run:
       - _common_apk
     steps:
@@ -150,7 +150,7 @@ workflows:
       # google play deploy
       - PACKAGE_NAME: "io.bitrise.realmtasks"
       - BITRISEIO_JSON_KEY_URL: $BITRISEIO_JSON_KEY_URL
-      - TRACK: "beta"
+      - TRACK: "alpha"
     before_run:
       - _common_apk
     steps:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -142,7 +142,7 @@ workflows:
           - mapping_file: ""
           - user_fraction: ""
 
-  # This is needed to test the untrack blocking versions, it should run after apk_deploy_test_1
+  # This is needed to test the possible shadowing of releases, it should run after apk_deploy_test_1
   apk_deploy_test_2:
     envs:
       # google services

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,19 +12,12 @@ workflows:
     - errcheck:
     - go-test:
     after_run:
-    - apk_deploy_test_1
     - aab_deploy_test
+    - apk_deploy_test_1
 
-  _build_start:
-    steps:
-      - build-router-start:
-          inputs:
-            - access_token: $BITRISE_ACCESS_TOKEN
-            - workflows: >
-                aab_deploy_test
-                apk_deploy_test_1
-                apk_deploy_test_2
-            - wait_for_builds: "true"
+  ci_untrack_phase2:
+    after_run:
+    - apk_deploy_test_2
 
   _common_apk:
     envs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -128,7 +128,7 @@ workflows:
     # google play deploy
     - PACKAGE_NAME: "io.bitrise.realmtasks"
     - BITRISEIO_JSON_KEY_URL: $BITRISEIO_JSON_KEY_URL
-    - TRACK: "alpha"
+    - TRACK: "beta"
     before_run:
       - _common_apk
     steps:
@@ -150,7 +150,7 @@ workflows:
       # google play deploy
       - PACKAGE_NAME: "io.bitrise.realmtasks"
       - BITRISEIO_JSON_KEY_URL: $BITRISEIO_JSON_KEY_URL
-      - TRACK: "beta"
+      - TRACK: "alpha"
     before_run:
       - _common_apk
     steps:

--- a/config.go
+++ b/config.go
@@ -13,15 +13,14 @@ import (
 
 // Configs stores the step's inputs
 type Configs struct {
-	JSONKeyPath             stepconf.Secret `env:"service_account_json_key_path,required"`
-	PackageName             string          `env:"package_name,required"`
-	AppPath                 string          `env:"app_path,required"`
-	ExpansionfilePath       string          `env:"expansionfile_path"`
-	Track                   string          `env:"track,required"`
-	UserFraction            float64         `env:"user_fraction,range]0.0..1.0["`
-	WhatsnewsDir            string          `env:"whatsnews_dir"`
-	MappingFile             string          `env:"mapping_file"`
-	UntrackBlockingVersions bool            `env:"untrack_blocking_versions,opt[true,false]"`
+	JSONKeyPath       stepconf.Secret `env:"service_account_json_key_path,required"`
+	PackageName       string          `env:"package_name,required"`
+	AppPath           string          `env:"app_path,required"`
+	ExpansionfilePath string          `env:"expansionfile_path"`
+	Track             string          `env:"track,required"`
+	UserFraction      float64         `env:"user_fraction,range]0.0..1.0["`
+	WhatsnewsDir      string          `env:"whatsnews_dir"`
+	MappingFile       string          `env:"mapping_file"`
 }
 
 // validate validates the Configs.

--- a/config.go
+++ b/config.go
@@ -84,10 +84,6 @@ func (c Configs) validateMappingFile() error {
 	return nil
 }
 
-func parseAPKList(list string) []string {
-	return strings.Split(list, "|")
-}
-
 func splitElements(list []string, sep string) (s []string) {
 	for _, e := range list {
 		s = append(s, strings.Split(e, sep)...)

--- a/main.go
+++ b/main.go
@@ -115,26 +115,6 @@ func updateTracks(configs Configs, service *androidpublisher.Service, appEdit *a
 	return nil
 }
 
-// unTrackBlockingVersions untracks the blocking versions.
-func unTrackBlockingVersions(configs Configs, service *androidpublisher.Service, appEdit *androidpublisher.AppEdit, versionCodes []int64) error {
-	if configs.Track == alphaTrackName {
-		fmt.Println()
-		log.Warnf("UntrackBlockingVersions is set, but selected track is: alpha, nothing to deactivate")
-		return nil
-	}
-
-	fmt.Println()
-	log.Infof("Deactivating blocking apk versions")
-	tracks, err := getAllTracks(configs.PackageName, service, appEdit)
-	if err != nil {
-		return fmt.Errorf("failed to list tracks, error: %s", err)
-	}
-
-	trackNamesToUpdate := trackNamesToUpdate(configs.Track, tracks)
-
-	return untrackFromTracks(trackNamesToUpdate, versionCodes, service, configs.PackageName, appEdit.Id)
-}
-
 func main() {
 	//
 	// Getting configs
@@ -163,7 +143,6 @@ func main() {
 		failf("Failed to create publisher service, error: %s", err)
 	}
 	log.Donef("Authenticated client created")
-	// ---
 
 	//
 	// Create insert edit
@@ -177,7 +156,6 @@ func main() {
 	}
 	log.Printf(" editID: %s", appEdit.Id)
 	log.Donef("Edit insert created")
-	// ---
 
 	//
 	// Upload applications
@@ -188,7 +166,6 @@ func main() {
 		failf("Failed to upload APKs: %v", err)
 	}
 	log.Donef("Applications uploaded")
-	// ---
 
 	// Update track
 	fmt.Println()
@@ -197,17 +174,6 @@ func main() {
 		failf("Failed to update track, reason: %v", err)
 	}
 	log.Donef("Track updated")
-	// ---
-
-	//
-	// Deactivate blocking apks
-	untrackApks := configs.UntrackBlockingVersions
-	if untrackApks {
-		if err := unTrackBlockingVersions(configs, service, appEdit, versionCodes); err != nil {
-			failf("Failed to untrack blocking versions: %s", err)
-		}
-	}
-	// ---
 
 	//
 	// Validate edit
@@ -218,7 +184,6 @@ func main() {
 		failf("Failed to validate edit, error: %s", err)
 	}
 	log.Donef("Edit is valid")
-	// ---
 
 	//
 	// Commit edit
@@ -230,5 +195,4 @@ func main() {
 	}
 
 	log.Donef("Edit committed")
-	// ---
 }

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func updateTracks(configs Configs, service *androidpublisher.Service, appEdit *a
 	if err != nil {
 		return err
 	}
-	printTrack(trackToUpdate, "Track to update:")
+	log.Infof("%s track will be updated.", trackToUpdate.Track)
 
 	newRelease, err := createTrackRelease(configs.WhatsnewsDir, versionCodes, configs.UserFraction)
 	if err != nil {

--- a/print.go
+++ b/print.go
@@ -1,22 +1,22 @@
 package main
 
 import (
-	"github.com/bitrise-io/go-utils/log"
+	"fmt"
+
 	"google.golang.org/api/androidpublisher/v3"
 )
 
-// printTrack prints out the given track to the console.
-func printTrack(track *androidpublisher.Track, prefix string) {
-	if prefix != "" {
-		log.Infof("%s", prefix)
+func trackToString(track *androidpublisher.Track) string {
+	s := fmt.Sprintf("%s track:\n", track.Track)
+	for i, release := range track.Releases {
+		s += fmt.Sprintf("- %s", releaseToString(release))
+		if i != len(track.Releases)-1 {
+			s += "\n"
+		}
 	}
-	log.Infof("%s", track.Track)
-	for _, release := range track.Releases {
-		printRelease(*release)
-	}
+	return s
 }
 
-// printRelease prints out the given release to the console.
-func printRelease(release androidpublisher.TrackRelease) {
-	log.Infof("Release '%s' has versionCodes: '%v', status: '%v", release.Name, release.VersionCodes, release.Status)
+func releaseToString(release *androidpublisher.TrackRelease) string {
+	return fmt.Sprintf("'%s' release versionCodes: %v, status: '%v'", release.Name, release.VersionCodes, release.Status)
 }

--- a/publish.go
+++ b/publish.go
@@ -237,7 +237,7 @@ func getAllTracks(packageName string, service *androidpublisher.Service, appEdit
 		return []*androidpublisher.Track{}, fmt.Errorf("failed to list tracks, error: %s", err)
 	}
 	for _, track := range listResponse.Tracks {
-		printTrack(track, "Found track:")
+		log.Infof(trackToString(track))
 	}
 	return listResponse.Tracks, nil
 }

--- a/publish.go
+++ b/publish.go
@@ -136,10 +136,8 @@ func updateListing(whatsNewsDir string, release *androidpublisher.TrackRelease) 
 		var releaseNotes []*androidpublisher.LocalizedText
 		for language, recentChanges := range recentChangesMap {
 			releaseNotes = append(releaseNotes, &androidpublisher.LocalizedText{
-				Language:        language,
-				Text:            recentChanges,
-				ForceSendFields: []string{},
-				NullFields:      []string{},
+				Language: language,
+				Text:     recentChanges,
 			})
 		}
 		release.ReleaseNotes = releaseNotes

--- a/publish.go
+++ b/publish.go
@@ -2,11 +2,9 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 
 	"github.com/bitrise-io/go-utils/fileutil"
@@ -18,11 +16,6 @@ import (
 const (
 	releaseStatusCompleted  = "completed"
 	releaseStatusInProgress = "inProgress"
-
-	alphaTrackName      = "alpha"
-	betaTrackName       = "beta"
-	rolloutTrackName    = "rollout"
-	productionTrackName = "production"
 )
 
 // uploadExpansionFiles uploads the expansion files for given applications, like .obb files.
@@ -211,91 +204,6 @@ func createTrackRelease(whatsNewsDir string, versionCodes googleapi.Int64s, user
 	}
 
 	return newRelease, nil
-}
-
-// trackNamesToUpdate returns the tracks that should be updated.
-func trackNamesToUpdate(track string, tracks []*androidpublisher.Track) []string {
-	var possibleTrackNamesToUpdate []string
-	switch track {
-	case betaTrackName:
-		possibleTrackNamesToUpdate = []string{alphaTrackName}
-	case rolloutTrackName, productionTrackName:
-		possibleTrackNamesToUpdate = []string{alphaTrackName, betaTrackName}
-	}
-
-	var trackNamesToUpdate []string
-	for _, track := range tracks {
-		for _, trackNameToUpdate := range possibleTrackNamesToUpdate {
-			if trackNameToUpdate == track.Track {
-				trackNamesToUpdate = append(trackNamesToUpdate, trackNameToUpdate)
-			}
-		}
-	}
-
-	log.Printf(" possible tracks to update: %v", trackNamesToUpdate)
-	return trackNamesToUpdate
-}
-
-// untrackFromTracks untracks the lower level versions.
-func untrackFromTracks(trackNamesToUpdate []string, versionCodes googleapi.Int64s, service *androidpublisher.Service, packageName string, appEditID string) error {
-	tracksService := androidpublisher.NewEditsTracksService(service)
-	anyTrackUpdated := false
-	for _, trackName := range trackNamesToUpdate {
-		tracksGetCall := tracksService.Get(packageName, appEditID, trackName)
-		track, err := tracksGetCall.Do()
-		if err != nil {
-			return fmt.Errorf("failed to get track (%s), error: %s", trackName, err)
-		}
-		for _, release := range track.Releases {
-			if hasBlockingVersionInRelease(release, versionCodes) {
-				anyTrackUpdated = true
-
-				release.VersionCodes = []int64{}
-				release.ForceSendFields = []string{"VersionCodes"}
-			}
-		}
-
-		if anyTrackUpdated {
-			log.Donef("Desired versions deactivated")
-		} else {
-			log.Donef("No blocking apk version found")
-		}
-		tracksUpdateCall := tracksService.Patch(packageName, appEditID, trackName, track)
-		if _, err := tracksUpdateCall.Do(); err != nil && err != io.EOF {
-			return fmt.Errorf("failed to update track (%s), error: %s", trackName, err)
-		}
-	}
-	return nil
-}
-
-// hasBlockingVersionInRelease checks if there is blocking version from a given release, which would shadow the given version.
-func hasBlockingVersionInRelease(release *androidpublisher.TrackRelease, newVersionCodes googleapi.Int64s) bool {
-	log.Printf("Checking app versions on release: %s", release.Name)
-	log.Infof("Current version codes: %v", release.VersionCodes)
-	log.Infof("New version codes: '%v'", newVersionCodes)
-
-	if len(release.VersionCodes) != len(newVersionCodes) {
-		log.Warnf("Mismatching app count, removing (%v) versions from release: %s", release.VersionCodes, release.Name)
-		return true
-	}
-
-	log.Debugf("The number of App version codes (current and new) are equal")
-	return hasShadowingVersions(release.VersionCodes, newVersionCodes)
-}
-
-// hasShadowingVersions returns true if any of the new version code is higher than the corresponding current.
-func hasShadowingVersions(currentVersionCodes googleapi.Int64s, newVersionCodes googleapi.Int64s) bool {
-	sort.Slice(currentVersionCodes, func(a, b int) bool { return currentVersionCodes[a] < currentVersionCodes[b] })
-	sort.Slice(newVersionCodes, func(a, b int) bool { return newVersionCodes[a] < newVersionCodes[b] })
-
-	for i := 0; i < len(newVersionCodes); i++ {
-		log.Debugf("Searching for shadowing versions, comparing (%v) and (%v)", currentVersionCodes[i], newVersionCodes[i])
-		if currentVersionCodes[i] < newVersionCodes[i] {
-			log.Infof("Shadowing app found, removing current (%v) version, adding new (%v)", currentVersionCodes[i], newVersionCodes[i])
-			return true
-		}
-	}
-	return false
 }
 
 // releaseStatusFromConfig gets the release status from the config value of user fraction.

--- a/publish_test.go
+++ b/publish_test.go
@@ -1,38 +1,8 @@
 package main
 
 import (
-	"reflect"
 	"testing"
-
-	"google.golang.org/api/androidpublisher/v3"
-	"google.golang.org/api/googleapi"
 )
-
-func Test_hasShadowingVersions(t *testing.T) {
-	tests := []struct {
-		name                string
-		currentVersionCodes googleapi.Int64s
-		newVersionCodes     googleapi.Int64s
-		want                bool
-	}{
-		{
-			"currentIsHigher", googleapi.Int64s{5, 6, 7, 8}, googleapi.Int64s{1, 2, 3, 4}, false,
-		},
-		{
-			"newIsHigher", googleapi.Int64s{5, 6, 7, 8}, googleapi.Int64s{9, 10, 11, 12}, true,
-		},
-		{
-			"mixed", googleapi.Int64s{5, 6, 7, 8}, googleapi.Int64s{4, 6, 8, 10}, true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := hasShadowingVersions(tt.currentVersionCodes, tt.newVersionCodes); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("hasShadowingVersions() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func Test_releaseStatusFromConfig(t *testing.T) {
 
@@ -98,27 +68,6 @@ func Test_validateExpansionFilePath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := validateExpansionFileConfig(tt.expFilePath); got != tt.want {
 				t.Errorf("validateExpansionFileConfig() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_removeBlockingVersionFromRelease(t *testing.T) {
-	tests := []struct {
-		name            string
-		release         *androidpublisher.TrackRelease
-		newVersionCodes googleapi.Int64s
-		want            bool
-	}{
-		{"hasShadowing1", &androidpublisher.TrackRelease{nil, "releaseName", nil, "status", 0, googleapi.Int64s{1, 2, 3, 4}, nil, nil}, googleapi.Int64s{5, 6, 7, 8}, true},
-		{"noShadowing1", &androidpublisher.TrackRelease{nil, "releaseName", nil, "status", 0, googleapi.Int64s{5, 6, 7, 8}, nil, nil}, googleapi.Int64s{1, 2, 3, 4}, false},
-		{"differentNumberOfVersions1", &androidpublisher.TrackRelease{nil, "releaseName", nil, "status", 0, googleapi.Int64s{5}, nil, nil}, googleapi.Int64s{1, 2, 3, 4}, true},
-		{"differentNumberOfVersions2", &androidpublisher.TrackRelease{nil, "releaseName", nil, "status", 0, googleapi.Int64s{5, 6, 7, 8}, nil, nil}, googleapi.Int64s{1}, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := hasBlockingVersionInRelease(tt.release, tt.newVersionCodes); got != tt.want {
-				t.Errorf("hasBlockingVersionInRelease() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/step.yml
+++ b/step.yml
@@ -145,6 +145,8 @@ inputs:
     opts:
       title: "Untrack blocking versions?"
       description: |-
+        Deprecated, will be ignored.
+
         Should deactivate apps, with lower version code on the given release.
 
         E.g.: 

--- a/step.yml
+++ b/step.yml
@@ -141,22 +141,3 @@ inputs:
       title: Location of your mapping.txt file
       description: |-
         The `mapping.txt` file provides a translation between the original and obfuscated class, method, and field names.
-  - untrack_blocking_versions: "true"
-    opts:
-      title: "Untrack blocking versions?"
-      description: |-
-        Deprecated, will be ignored.
-
-        Should deactivate apps, with lower version code on the given release.
-
-        E.g.: 
-        If you have an __active apk on alpha__ track with version code: `42`.
-        And you try to __upload a new version (`43`)__, you will see an error:
-
-        `Version 42 of this app can not be downloaded by any devices as they will all receive APKs with higher version codes`
-
-        To avoid this issue set this input to: `"true"` and the step will deactivate every app with lower version code, on lower level tracks.
-      value_options:
-      - "true"
-      - "false"
-      is_required: true


### PR DESCRIPTION
Specifying only the actual release in the track update call.

Removed untrack blocking releases feature as could not reproduce shadowing between tracks.

https://bitrise.atlassian.net/wiki/spaces/TOOL/pages/52690961/Google+Play+Console+androidpublisher+API+investigation+for+google-play-deploy

Added test part 2 for untrack blocking apk function.