### PR TITLE
Remove check for multiple .aab files

### DIFF
--- a/config.go
+++ b/config.go
@@ -133,12 +133,8 @@ func (c Configs) appPaths() ([]string, []string) {
 		warnings = append(warnings, fmt.Sprintf("Both .aab and .apk files provided, using the .aab file(s): %s", strings.Join(aabs, ",")))
 	}
 
-	if len(aabs) > 1 {
-		warnings = append(warnings, fmt.Sprintf("More than 1 .aab files provided, using the first: %s", aabs[0]))
-	}
-
 	if len(aabs) > 0 {
-		return aabs[:1], warnings
+		return aabs, warnings
 	}
 
 	return apks, warnings

--- a/config_test.go
+++ b/config_test.go
@@ -112,12 +112,12 @@ func TestConfigs_appPaths(t *testing.T) {
 			wantWarnings: []string{"Both .aab and .apk files provided, using the .aab file(s): app.aab"},
 		},
 		{
-			name: "uses first aab",
+			name: "multiple .aab",
 			config: Configs{
 				AppPath: "app.aab\napp1.aab",
 			},
-			wantApps:     []string{"app.aab"},
-			wantWarnings: []string{"More than 1 .aab files provided, using the first: app.aab"},
+			wantApps:     []string{"app.aab", "app1.aab"},
+			wantWarnings: []string{"More than 1 .aab files provided, using all"},
 		},
 		{
 			name: "unknown extension",
@@ -132,8 +132,8 @@ func TestConfigs_appPaths(t *testing.T) {
 			config: Configs{
 				AppPath: `/bitrise/deploy/app-bitrise-signed.aab\n/bitrise/deploy/app.aab`,
 			},
-			wantApps:     []string{"/bitrise/deploy/app-bitrise-signed.aab"},
-			wantWarnings: []string{"More than 1 .aab files provided, using the first: /bitrise/deploy/app-bitrise-signed.aab"},
+			wantApps:     []string{"/bitrise/deploy/app-bitrise-signed.aab", "/bitrise/deploy/app.aab"},
+			wantWarnings: []string{"More than 1 .aab files provided, using all"},
 		},
 	}
 	for _, tt := range tests {

--- a/config_test.go
+++ b/config_test.go
@@ -117,7 +117,6 @@ func TestConfigs_appPaths(t *testing.T) {
 				AppPath: "app.aab\napp1.aab",
 			},
 			wantApps:     []string{"app.aab", "app1.aab"},
-			wantWarnings: []string{"More than 1 .aab files provided, using all"},
 		},
 		{
 			name: "unknown extension",
@@ -133,7 +132,6 @@ func TestConfigs_appPaths(t *testing.T) {
 				AppPath: `/bitrise/deploy/app-bitrise-signed.aab\n/bitrise/deploy/app.aab`,
 			},
 			wantApps:     []string{"/bitrise/deploy/app-bitrise-signed.aab", "/bitrise/deploy/app.aab"},
-			wantWarnings: []string{"More than 1 .aab files provided, using all"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This resolved the issue with multiple `.aab` uploads to Google Play:
https://discuss.bitrise.io/t/deploy-multiple-aab-android-app-bundles-with-a-single-step/11848

Related to https://github.com/bitrise-steplib/steps-google-play-deploy/issues/69