### PR TITLE
Added new parameter for setting the release name

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ type Configs struct {
 	UserFraction      float64         `env:"user_fraction,range]0.0..1.0["`
 	WhatsnewsDir      string          `env:"whatsnews_dir"`
 	MappingFile       string          `env:"mapping_file"`
+	ReleaseName       string          `env:"release_name"`
 }
 
 // validate validates the Configs.

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func uploadApplications(configs Configs, service *androidpublisher.Service, appE
 func updateTracks(configs Configs, service *androidpublisher.Service, appEdit *androidpublisher.AppEdit, versionCodes []int64) error {
 	editsTracksService := androidpublisher.NewEditsTracksService(service)
 
-	newRelease, err := createTrackRelease(configs.WhatsnewsDir, versionCodes, configs.UserFraction)
+	newRelease, err := createTrackRelease(configs.WhatsnewsDir, versionCodes, configs.UserFraction, configs.ReleaseName)
 	if err != nil {
 		return err
 	}

--- a/publish.go
+++ b/publish.go
@@ -187,7 +187,7 @@ func readLocalisedRecentChanges(recentChangesDir string) (map[string]string, err
 }
 
 // createTrackRelease returns a release object with the given version codes and adds the listing information.
-func createTrackRelease(whatsNewsDir string, versionCodes googleapi.Int64s, userFraction float64) (*androidpublisher.TrackRelease, error) {
+func createTrackRelease(whatsNewsDir string, versionCodes googleapi.Int64s, userFraction float64, releaseName string) (*androidpublisher.TrackRelease, error) {
 	status := releaseStatusFromConfig(userFraction)
 
 	newRelease := &androidpublisher.TrackRelease{
@@ -195,6 +195,10 @@ func createTrackRelease(whatsNewsDir string, versionCodes googleapi.Int64s, user
 		Status:       status,
 	}
 	log.Infof("Release version codes are: %v", newRelease.VersionCodes)
+	if releaseName != "" {
+		newRelease.Name = releaseName
+	}
+
 	if userFraction != 0 {
 		newRelease.UserFraction = userFraction
 	}

--- a/step.yml
+++ b/step.yml
@@ -141,3 +141,9 @@ inputs:
       title: Location of your mapping.txt file
       description: |-
         The `mapping.txt` file provides a translation between the original and obfuscated class, method, and field names.
+  - release_name:
+    opts:
+      title: Name of the release
+      description: |-
+        By default Play Store uses the application versionName as the name of the release, but you can override it here.
+      is_required: false


### PR DESCRIPTION
The current version of the step does not let the user define the Play Store internal release name but relies on the default behaviour where Play Store retrieves the release name from the APK/AAB versionName. Overriding this feature is useful because it provides a way to tell one release from another even if they have the same versionName. This is especially true in the new Play Store Console where the versionCode is not always visible.

While it's true that one could work around this limitation by rewriting the versionName entirely, it also makes this release name visible to the end user, which might not always be ideal.

Fortunately this is a very simple change – the release name is just an extra property in the TrackRelease struct. And a word of warning: this is the first time I'm modifying a Bitrise step _and_ writing in Go.