### PR TITLE
Add optional release_name input parameter

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -141,6 +141,7 @@ workflows:
             - app_path: $BITRISE_SIGNED_AAB_PATH
             - track: $TRACK
             - user_fraction: 0.6
+            - release_name: "Overwritten release name"
 
   _common_apk:
     envs:

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ type Configs struct {
 	UpdatePriority    int             `env:"update_priority,range[0..5]"`
 	WhatsnewsDir      string          `env:"whatsnews_dir"`
 	MappingFile       string          `env:"mapping_file"`
+	ReleaseName       string          `env:"release_name"`
 }
 
 // validate validates the Configs.

--- a/config_test.go
+++ b/config_test.go
@@ -116,7 +116,7 @@ func TestConfigs_appPaths(t *testing.T) {
 			config: Configs{
 				AppPath: "app.aab\napp1.aab",
 			},
-			wantApps:     []string{"app.aab", "app1.aab"},
+			wantApps: []string{"app.aab", "app1.aab"},
 		},
 		{
 			name: "unknown extension",
@@ -131,7 +131,7 @@ func TestConfigs_appPaths(t *testing.T) {
 			config: Configs{
 				AppPath: `/bitrise/deploy/app-bitrise-signed.aab\n/bitrise/deploy/app.aab`,
 			},
-			wantApps:     []string{"/bitrise/deploy/app-bitrise-signed.aab", "/bitrise/deploy/app.aab"},
+			wantApps: []string{"/bitrise/deploy/app-bitrise-signed.aab", "/bitrise/deploy/app.aab"},
 		},
 	}
 	for _, tt := range tests {

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func uploadApplications(configs Configs, service *androidpublisher.Service, appE
 func updateTracks(configs Configs, service *androidpublisher.Service, appEdit *androidpublisher.AppEdit, versionCodes []int64) error {
 	editsTracksService := androidpublisher.NewEditsTracksService(service)
 
-	newRelease, err := createTrackRelease(configs.WhatsnewsDir, versionCodes, configs.UserFraction, configs.UpdatePriority)
+	newRelease, err := createTrackRelease(configs.WhatsnewsDir, versionCodes, configs.UserFraction, configs.UpdatePriority, configs.ReleaseName)
 	if err != nil {
 		return err
 	}

--- a/publish.go
+++ b/publish.go
@@ -187,7 +187,7 @@ func readLocalisedRecentChanges(recentChangesDir string) (map[string]string, err
 }
 
 // createTrackRelease returns a release object with the given version codes and adds the listing information.
-func createTrackRelease(whatsNewsDir string, versionCodes googleapi.Int64s, userFraction float64, updatePriority int) (*androidpublisher.TrackRelease, error) {
+func createTrackRelease(whatsNewsDir string, versionCodes googleapi.Int64s, userFraction float64, updatePriority int, releaseName string) (*androidpublisher.TrackRelease, error) {
 	status := releaseStatusFromConfig(userFraction)
 
 	newRelease := &androidpublisher.TrackRelease{
@@ -198,6 +198,10 @@ func createTrackRelease(whatsNewsDir string, versionCodes googleapi.Int64s, user
 	log.Infof("Release version codes are: %v", newRelease.VersionCodes)
 	if userFraction != 0 {
 		newRelease.UserFraction = userFraction
+	}
+
+	if releaseName != "" {
+		newRelease.Name = releaseName
 	}
 
 	if err := updateListing(whatsNewsDir, newRelease); err != nil {

--- a/step.yml
+++ b/step.yml
@@ -8,21 +8,21 @@ description: |-
   To use this step:
 
   1. Upload the first apk/aab manually (using the web interface):
-  
+
     Visit the [Google Play Console](https://play.google.com/apps/publish) -> All applications -> CREATE APPLICATION
 
   2. Link your Google Play Developer Console to an API project:
-  
+
     Described in [Google Play Developer API](https://developers.google.com/android-publisher/getting_started)'s __Linking your API Project__ section
 
   3. Setup API Access Clients, using a service account:
-  
+
     Described in [Google Play Developer API](https://developers.google.com/android-publisher/getting_started)'s __Using a service account__ section
 
     __NOTE__: When you create your service account on the Google Play Developer Console, choose json as `Key Type`.
 
   4. Grant the necessary rights to the service account:
-  
+
     Visit the [Google Play Console](https://play.google.com/apps/publish) -> Settings -> Users & permissions -> Invite new user.
 
     Due to the way the Google Play Publisher API works, you have to grant at least the following permissions to that service account:
@@ -32,7 +32,7 @@ description: |-
       - STORE PRESENCE: Edit store listing, pricing & distribution
 
   5. OPTIONAL - Add translations for your Store Listing:
-  
+
     To allow the step to assign your 'whatsnew' files to the uploaded apk version.
 
     Visit [Play Console Help](https://support.google.com/googleplay/android-developer/answer/3125566?hl=en)'s __Add translations for your Store Listing__ section
@@ -98,11 +98,11 @@ inputs:
       summary: The track in which you want to assign the uploaded app.
       description: |-
         The track in which you want to assign the uploaded app. 
-        
+
         Can be one of the built-in tracks: internal, alpha, beta, production.
-        
+
         Or you can set your custom track name as well. 
-        
+
         For example: `pre-release`, or any of your closed track you added in Google Play Developer Console.
       is_required: true
   - user_fraction:
@@ -111,6 +111,12 @@ inputs:
       description: |-
         Portion of the users who should get the staged version of the app. Accepts values between 0.0 and 1.0 (exclusive-exclusive).
         To release to all users, this input should not be defined (or should be blank).
+      is_required: false
+  - release_name:
+    opts:
+      title: Name of the release
+      description: |-
+        The name of the release. By default Play Store generates the name from the APK's versionName.
       is_required: false
   - update_priority: 0
     opts:
@@ -132,7 +138,7 @@ inputs:
         what's new file name pattern: `whatsnew-LOCALE`
 
         Example:
-        
+
         ```
         + - [PATH/TO/WHATSNEW]
             |


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MINOR_ [version update](https://semver.org/)

### Context

Adding `release_name` input parameter which can be used to provide the name of the release.

This a copy PR or #99 as the author's user is removed from Github.

Resolves: #99 
Resolves: [STEP-421](https://bitrise.atlassian.net/browse/STEP-421)

### Changes

- Introduce `release_name` input as an optional parameter.
- Extend `aab_deploy_test` workflow with the new parameter.
- Updated `step.yml`.

### Investigation details

- https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#Release
