### PR TITLE
Introduce `status` input

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ type Configs struct {
 	WhatsnewsDir      string          `env:"whatsnews_dir"`
 	MappingFile       string          `env:"mapping_file"`
 	ReleaseName       string          `env:"release_name"`
+	Status            string          `env:"status,opt[draft,inProgress,completed]"`
 }
 
 // validate validates the Configs.

--- a/config.go
+++ b/config.go
@@ -23,7 +23,7 @@ type Configs struct {
 	WhatsnewsDir      string          `env:"whatsnews_dir"`
 	MappingFile       string          `env:"mapping_file"`
 	ReleaseName       string          `env:"release_name"`
-	Status            string          `env:"status,opt[draft,inProgress,completed]"`
+	Status            string          `env:"status"`
 }
 
 // validate validates the Configs.

--- a/config_test.go
+++ b/config_test.go
@@ -8,6 +8,55 @@ import (
 	"github.com/bitrise-io/go-steputils/stepconf"
 )
 
+func Test_status(t *testing.T) {
+	type cfgs struct {
+		Status  string `env:"status,opt[draft,inProgress,completed]"`
+		Input   string
+		Value   string
+		WantErr bool
+	}
+
+	for _, cfg := range []cfgs{
+		{
+			Input:   "",
+			Value:   "",
+			WantErr: true,
+		},
+		{
+			Input:   "draft",
+			Value:   "draft",
+			WantErr: false,
+		},
+		{
+			Input:   "inProgress",
+			Value:   "inProgress",
+			WantErr: false,
+		},
+		{
+			Input:   "completed",
+			Value:   "completed",
+			WantErr: false,
+		},
+		{
+			Input:   "notListedStatus",
+			Value:   "",
+			WantErr: true,
+		},
+	} {
+		if err := os.Setenv("status", cfg.Input); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := stepconf.Parse(&cfg); err != nil && !cfg.WantErr {
+			t.Fatal(err)
+		}
+
+		if cfg.Status != cfg.Value {
+			t.Fatal("Invalid status")
+		}
+	}
+}
+
 func Test_fraction(t *testing.T) {
 	type cfgs struct {
 		UserFraction float64 `env:"user_fraction,range]0.0..1.0["`

--- a/config_test.go
+++ b/config_test.go
@@ -8,55 +8,6 @@ import (
 	"github.com/bitrise-io/go-steputils/stepconf"
 )
 
-func Test_status(t *testing.T) {
-	type cfgs struct {
-		Status  string `env:"status,opt[draft,inProgress,completed]"`
-		Input   string
-		Value   string
-		WantErr bool
-	}
-
-	for _, cfg := range []cfgs{
-		{
-			Input:   "",
-			Value:   "",
-			WantErr: true,
-		},
-		{
-			Input:   releaseStatusDraft,
-			Value:   releaseStatusDraft,
-			WantErr: false,
-		},
-		{
-			Input:   releaseStatusInProgress,
-			Value:   releaseStatusInProgress,
-			WantErr: false,
-		},
-		{
-			Input:   releaseStatusCompleted,
-			Value:   releaseStatusCompleted,
-			WantErr: false,
-		},
-		{
-			Input:   "notListedStatus",
-			Value:   "",
-			WantErr: true,
-		},
-	} {
-		if err := os.Setenv("status", cfg.Input); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := stepconf.Parse(&cfg); err != nil && !cfg.WantErr {
-			t.Fatal(err)
-		}
-
-		if cfg.Status != cfg.Value {
-			t.Fatal("Invalid status")
-		}
-	}
-}
-
 func Test_fraction(t *testing.T) {
 	type cfgs struct {
 		UserFraction float64 `env:"user_fraction,range]0.0..1.0["`

--- a/config_test.go
+++ b/config_test.go
@@ -23,18 +23,18 @@ func Test_status(t *testing.T) {
 			WantErr: true,
 		},
 		{
-			Input:   "draft",
-			Value:   "draft",
+			Input:   releaseStatusDraft,
+			Value:   releaseStatusDraft,
 			WantErr: false,
 		},
 		{
-			Input:   "inProgress",
-			Value:   "inProgress",
+			Input:   releaseStatusInProgress,
+			Value:   releaseStatusInProgress,
 			WantErr: false,
 		},
 		{
-			Input:   "completed",
-			Value:   "completed",
+			Input:   releaseStatusCompleted,
+			Value:   releaseStatusCompleted,
 			WantErr: false,
 		},
 		{

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func uploadApplications(configs Configs, service *androidpublisher.Service, appE
 func updateTracks(configs Configs, service *androidpublisher.Service, appEdit *androidpublisher.AppEdit, versionCodes []int64) error {
 	editsTracksService := androidpublisher.NewEditsTracksService(service)
 
-	newRelease, err := createTrackRelease(configs.WhatsnewsDir, versionCodes, configs.UserFraction, configs.UpdatePriority, configs.ReleaseName)
+	newRelease, err := createTrackRelease(configs, versionCodes)
 	if err != nil {
 		return err
 	}

--- a/publish.go
+++ b/publish.go
@@ -16,6 +16,7 @@ import (
 const (
 	releaseStatusCompleted  = "completed"
 	releaseStatusInProgress = "inProgress"
+	releaseStatusDraft      = "draft"
 )
 
 // uploadExpansionFiles uploads the expansion files for given applications, like .obb files.
@@ -187,24 +188,27 @@ func readLocalisedRecentChanges(recentChangesDir string) (map[string]string, err
 }
 
 // createTrackRelease returns a release object with the given version codes and adds the listing information.
-func createTrackRelease(whatsNewsDir string, versionCodes googleapi.Int64s, userFraction float64, updatePriority int, releaseName string) (*androidpublisher.TrackRelease, error) {
-	status := releaseStatusFromConfig(userFraction)
-
+func createTrackRelease(config Configs, versionCodes googleapi.Int64s) (*androidpublisher.TrackRelease, error) {
 	newRelease := &androidpublisher.TrackRelease{
 		VersionCodes:        versionCodes,
-		Status:              status,
-		InAppUpdatePriority: int64(updatePriority),
+		Status:              config.Status,
+		InAppUpdatePriority: int64(config.UpdatePriority),
 	}
 	log.Infof("Release version codes are: %v", newRelease.VersionCodes)
-	if userFraction != 0 {
-		newRelease.UserFraction = userFraction
+
+	if config.Status == "" {
+		newRelease.Status = releaseStatusFromConfig(config.UserFraction)
 	}
 
-	if releaseName != "" {
-		newRelease.Name = releaseName
+	if config.Status == releaseStatusInProgress {
+		newRelease.UserFraction = config.UserFraction
 	}
 
-	if err := updateListing(whatsNewsDir, newRelease); err != nil {
+	if config.ReleaseName != "" {
+		newRelease.Name = config.ReleaseName
+	}
+
+	if err := updateListing(config.WhatsnewsDir, newRelease); err != nil {
 		return nil, fmt.Errorf("failed to update listing, reason: %v", err)
 	}
 

--- a/publish.go
+++ b/publish.go
@@ -196,11 +196,11 @@ func createTrackRelease(config Configs, versionCodes googleapi.Int64s) (*android
 	}
 	log.Infof("Release version codes are: %v", newRelease.VersionCodes)
 
-	if config.Status == "" {
+	if newRelease.Status == "" {
 		newRelease.Status = releaseStatusFromConfig(config.UserFraction)
 	}
 
-	if config.Status == releaseStatusInProgress {
+	if newRelease.Status == releaseStatusInProgress {
 		newRelease.UserFraction = config.UserFraction
 	}
 

--- a/publish.go
+++ b/publish.go
@@ -201,7 +201,7 @@ func createTrackRelease(config Configs, versionCodes googleapi.Int64s) (*android
 		newRelease.Status = releaseStatusFromConfig(config.UserFraction)
 	}
 
-	if shouldApplyUserFraction(config.Status) {
+	if shouldApplyUserFraction(newRelease.Status) {
 		newRelease.UserFraction = config.UserFraction
 	}
 

--- a/publish.go
+++ b/publish.go
@@ -17,6 +17,7 @@ const (
 	releaseStatusCompleted  = "completed"
 	releaseStatusInProgress = "inProgress"
 	releaseStatusDraft      = "draft"
+	releaseStatusHalted     = "halted"
 )
 
 // uploadExpansionFiles uploads the expansion files for given applications, like .obb files.
@@ -200,7 +201,7 @@ func createTrackRelease(config Configs, versionCodes googleapi.Int64s) (*android
 		newRelease.Status = releaseStatusFromConfig(config.UserFraction)
 	}
 
-	if newRelease.Status == releaseStatusInProgress {
+	if shouldApplyUserFraction(config.Status) {
 		newRelease.UserFraction = config.UserFraction
 	}
 
@@ -222,4 +223,8 @@ func releaseStatusFromConfig(userFraction float64) string {
 		return releaseStatusInProgress
 	}
 	return releaseStatusCompleted
+}
+
+func shouldApplyUserFraction(status string) bool {
+	return status == releaseStatusInProgress || status == releaseStatusHalted
 }

--- a/publish_test.go
+++ b/publish_test.go
@@ -42,21 +42,21 @@ func Test_verifyStatusOfTheCreatedRelease(t *testing.T) {
 
 func Test_verifyUserFractionOfTheCreatedRelease(t *testing.T) {
 	tests := []struct {
-		name           string
-		config         Configs
-		expectedStatus string
+		name                 string
+		config               Configs
+		expectedUserFraction float64
 	}{
 		{
-			"Given the user fraction is equal to 0 and the status is not set when the release is created then expect the status to be COMPLETED",
-			Configs{UserFraction: 0}, releaseStatusCompleted,
+			"Given status is IN_PROGRESS and the user fraction is set when the release is created then expect the user fraction to be applied",
+			Configs{UserFraction: 1, Status: releaseStatusInProgress}, 1,
 		},
 		{
-			"Given the user fraction is greather than 0 and the status is not set when the release is created then expect the status to be IN_PROGRESS",
-			Configs{UserFraction: 0.5}, releaseStatusInProgress,
+			"Given status is DRAFT and the user fraction is set when the release is created then expect the user fraction not to be applied",
+			Configs{UserFraction: 1, Status: releaseStatusDraft}, 0,
 		},
 		{
-			"Given the status when the release is created then expect the status to be the same as in the config",
-			Configs{Status: releaseStatusDraft}, releaseStatusDraft,
+			"Given status is COMPLETED and the user fraction is set when the release is created then expect the user fraction not to be applied",
+			Configs{UserFraction: 1, Status: releaseStatusCompleted}, 0,
 		},
 	}
 
@@ -65,33 +65,10 @@ func Test_verifyUserFractionOfTheCreatedRelease(t *testing.T) {
 			trackRelease, err := createTrackRelease(tt.config, []int64{})
 
 			assert.NoError(t, err)
-			assert.Equal(t, tt.expectedStatus, trackRelease.Status)
+			assert.Equal(t, tt.expectedUserFraction, trackRelease.UserFraction)
 		})
 	}
 }
-
-// func Test_shouldApplyUserFraction(t *testing.T) {
-// 	tests := []struct {
-// 		name         string
-// 		status       string
-// 		userFraction float64
-// 		want         bool
-// 	}{
-// 		{"1", releaseStatusCompleted, 0, false},
-// 		{"2", releaseStatusCompleted, 0.5, false},
-// 		{"4", releaseStatusDraft, 0, false},
-// 		{"6", releaseStatusDraft, 1, false},
-// 		{"7", releaseStatusInProgress, 0, false},
-// 		{"9", releaseStatusInProgress, 1, true},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			if got := shouldApplyUserFraction(tt.status, tt.userFraction); got != tt.want {
-// 				t.Errorf("releaseStatusFromConfig() = %v, want %v", got, tt.want)
-// 			}
-// 		})
-// 	}
-// }
 
 func Test_releaseStatusFromConfig(t *testing.T) {
 

--- a/publish_test.go
+++ b/publish_test.go
@@ -6,7 +6,92 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func Test_verifyStatusOfTheCreatedRelease(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         Configs
+		expectedStatus string
+	}{
+		{
+			"Given the user fraction is equal to 0 and the status is not set when the release is created then expect the status to be COMPLETED",
+			Configs{UserFraction: 0}, releaseStatusCompleted,
+		},
+		{
+			"Given the user fraction is greather than 0 and the status is not set when the release is created then expect the status to be IN_PROGRESS",
+			Configs{UserFraction: 0.5}, releaseStatusInProgress,
+		},
+		{
+			"Given the status when the release is created then expect the status to be the same as in the config",
+			Configs{Status: releaseStatusDraft}, releaseStatusDraft,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trackRelease, err := createTrackRelease(tt.config, []int64{})
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedStatus, trackRelease.Status)
+		})
+	}
+}
+
+func Test_verifyUserFractionOfTheCreatedRelease(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         Configs
+		expectedStatus string
+	}{
+		{
+			"Given the user fraction is equal to 0 and the status is not set when the release is created then expect the status to be COMPLETED",
+			Configs{UserFraction: 0}, releaseStatusCompleted,
+		},
+		{
+			"Given the user fraction is greather than 0 and the status is not set when the release is created then expect the status to be IN_PROGRESS",
+			Configs{UserFraction: 0.5}, releaseStatusInProgress,
+		},
+		{
+			"Given the status when the release is created then expect the status to be the same as in the config",
+			Configs{Status: releaseStatusDraft}, releaseStatusDraft,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trackRelease, err := createTrackRelease(tt.config, []int64{})
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedStatus, trackRelease.Status)
+		})
+	}
+}
+
+// func Test_shouldApplyUserFraction(t *testing.T) {
+// 	tests := []struct {
+// 		name         string
+// 		status       string
+// 		userFraction float64
+// 		want         bool
+// 	}{
+// 		{"1", releaseStatusCompleted, 0, false},
+// 		{"2", releaseStatusCompleted, 0.5, false},
+// 		{"4", releaseStatusDraft, 0, false},
+// 		{"6", releaseStatusDraft, 1, false},
+// 		{"7", releaseStatusInProgress, 0, false},
+// 		{"9", releaseStatusInProgress, 1, true},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			if got := shouldApplyUserFraction(tt.status, tt.userFraction); got != tt.want {
+// 				t.Errorf("releaseStatusFromConfig() = %v, want %v", got, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
 func Test_releaseStatusFromConfig(t *testing.T) {
 

--- a/publish_test.go
+++ b/publish_test.go
@@ -51,6 +51,10 @@ func Test_verifyUserFractionOfTheCreatedRelease(t *testing.T) {
 			Configs{UserFraction: 1, Status: releaseStatusInProgress}, 1,
 		},
 		{
+			"Given status is HALTED and the user fraction is set when the release is created then expect the user fraction to be applied",
+			Configs{UserFraction: 1, Status: releaseStatusHalted}, 1,
+		},
+		{
 			"Given status is DRAFT and the user fraction is set when the release is created then expect the user fraction not to be applied",
 			Configs{UserFraction: 1, Status: releaseStatusDraft}, 0,
 		},

--- a/step.yml
+++ b/step.yml
@@ -124,7 +124,9 @@ inputs:
   - status:
     opts:
       title: Status
-      description: The status of a release.
+      description: |-
+        The status of a release.
+        For more information see here: https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#Status
       is_required: false
   - release_name:
     opts:

--- a/step.yml
+++ b/step.yml
@@ -117,17 +117,15 @@ inputs:
       title: User Fraction
       description: |-
         Portion of the users who should get the staged version of the app. Accepts values between 0.0 and 1.0 (exclusive-exclusive).
+        Only applied if the `status` is set to `inProgress`.
+        
         To release to all users, this input should not be defined (or should be blank).
       is_required: false
   - status:
     opts:
       title: Status
-      description: The status of a release
+      description: The status of a release.
       is_required: false
-      value_options:
-      - "draft"
-      - "inProgress"
-      - "completed"
   - release_name:
     opts:
       title: Name of the release

--- a/step.yml
+++ b/step.yml
@@ -117,7 +117,7 @@ inputs:
       title: User Fraction
       description: |-
         Portion of the users who should get the staged version of the app. Accepts values between 0.0 and 1.0 (exclusive-exclusive).
-        Only applies if the `Status` is set to `inProgress`.
+        Only applies if `Status` is `inProgress` or `halted`.
 
         To release to all users, this input should not be defined (or should be blank).
       is_required: false

--- a/step.yml
+++ b/step.yml
@@ -117,8 +117,8 @@ inputs:
       title: User Fraction
       description: |-
         Portion of the users who should get the staged version of the app. Accepts values between 0.0 and 1.0 (exclusive-exclusive).
-        Only applied if the `status` is set to `inProgress`.
-        
+        Only applies if the `Status` is set to `inProgress`.
+
         To release to all users, this input should not be defined (or should be blank).
       is_required: false
   - status:

--- a/step.yml
+++ b/step.yml
@@ -119,6 +119,15 @@ inputs:
         Portion of the users who should get the staged version of the app. Accepts values between 0.0 and 1.0 (exclusive-exclusive).
         To release to all users, this input should not be defined (or should be blank).
       is_required: false
+  - status:
+    opts:
+      title: Status
+      description: The status of a release
+      is_required: false
+      value_options:
+      - "draft"
+      - "inProgress"
+      - "completed"
   - release_name:
     opts:
       title: Name of the release


### PR DESCRIPTION
https://bitrise.atlassian.net/browse/STEP-301

### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MINOR_ [version update](https://semver.org/)

### Context
Previously, the status of the release was determined based on the value of the `user fraction` input. This approach made it impossible to set anything but `completed` or `inProgress`. Some of the users filed [issues](https://github.com/bitrise-steplib/steps-google-play-deploy/issues/68) that they would also like to create a `draft` release besides the others. This pull request contains all of the changes that needed to be made in order to support the `draft` release status as well.

### Changes
- A new Step input called `status` has introduced.
- The input is optional to preserve backward compatibility. If it is not set, the status of the release is calculated as in the past (based on the value of the `user fraction` input).
- Based on the Google API [documentation](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#release), the `user fraction` input is only applied if the status of the release is `inProgress` or `halted`.
- Unit tests created to cover the logic changes.

### Investigation details
See [this](https://bitrise.atlassian.net/browse/STEP-193) ticket for the details of the investigation.
