### PR TITLE
Support uploading multiple mapping files

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -47,7 +47,9 @@ func Test_fraction(t *testing.T) {
 	}
 }
 
-func Test_parseAppList(t *testing.T) {
+// TODO: test mapping input list
+
+func Test_parseInputList(t *testing.T) {
 	tests := []struct {
 		name     string
 		list     string
@@ -81,8 +83,8 @@ func Test_parseAppList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if gotApps := parseAppList(tt.list); !reflect.DeepEqual(gotApps, tt.wantApps) {
-				t.Errorf("parseAppList() = %v, want %v", gotApps, tt.wantApps)
+			if gotApps := parseInputList(tt.list); !reflect.DeepEqual(gotApps, tt.wantApps) {
+				t.Errorf("parseInputList() = %v, want %v", gotApps, tt.wantApps)
 			}
 		})
 	}

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -86,6 +86,7 @@ workflows:
         - package_name: $PACKAGE_NAME
         - app_path: $BITRISE_DEPLOY_DIR/Wearable-release-bitrise-signed.aab|$BITRISE_DEPLOY_DIR/Application-release-bitrise-signed.aab
         - track: $TRACK
+        - mapping_file: $BITRISE_DEPLOY_DIR/Wearable-mapping.txt|$BITRISE_DEPLOY_DIR/Application-mapping.txt
 
   test_aab_deploy:
     envs:

--- a/publish.go
+++ b/publish.go
@@ -74,16 +74,16 @@ func validateExpansionFileConfig(expFileEntry string) bool {
 	return strings.HasPrefix(cleanExpFileConfigEntry, "main:") || strings.HasPrefix(cleanExpFileConfigEntry, "patch:")
 }
 
-// uploadMappingFile uploads the mapping files (that are used for deobfuscation) to Google Play.
-func uploadMappingFile(service *androidpublisher.Service, configs Configs, appEditID string, versionCode int64) error {
-	log.Debugf("Getting mapping file from %v", configs.MappingFile)
-	mappingFile, err := os.Open(configs.MappingFile)
+// uploadMappingFile uploads a given mapping file to a given app artifact (based on versionCode) to Google Play.
+func uploadMappingFile(service *androidpublisher.Service, appEditID string, versionCode int64, packageName string, filePath string) error {
+	log.Debugf("Getting mapping file from %v", filePath)
+	mappingFile, err := os.Open(filePath)
 	if err != nil {
-		return fmt.Errorf("failed to read mapping file (%s), error: %s", configs.MappingFile, err)
+		return fmt.Errorf("failed to read mapping file (%s), error: %s", filePath, err)
 	}
-	log.Debugf("Uploading mapping file %v with package name '%v', AppEditId '%v', version code '%v'", configs.MappingFile, configs.PackageName, appEditID, versionCode)
+	log.Debugf("Uploading mapping file %v with package name '%v', AppEditId '%v', version code '%v'", filePath, packageName, appEditID, versionCode)
 	editsDeobfuscationFilesService := androidpublisher.NewEditsDeobfuscationfilesService(service)
-	editsDeobfuscationFilesUploadCall := editsDeobfuscationFilesService.Upload(configs.PackageName, appEditID, versionCode, "proguard")
+	editsDeobfuscationFilesUploadCall := editsDeobfuscationFilesService.Upload(packageName, appEditID, versionCode, "proguard")
 	editsDeobfuscationFilesUploadCall.Media(mappingFile, googleapi.ContentType("application/octet-stream"))
 
 	if _, err = editsDeobfuscationFilesUploadCall.Do(); err != nil {

--- a/step.yml
+++ b/step.yml
@@ -159,9 +159,11 @@ inputs:
       - "./whatsnew" # what's new files are in the whatsnew directory
 - mapping_file: "$BITRISE_MAPPING_PATH"
   opts:
-    title: Location of your mapping.txt file
+    title: Mapping txt file path
     description: |-
       The `mapping.txt` file provides a translation between the original and obfuscated class, method, and field names.
+
+      In case of deploying [multiple artifacts](https://developer.android.com/google/play/publishing/multiple-apks.html), you can specify multiple mapping.txt files as a newline (`\n`) or pipe (`|`) separated list. The order of mapping files should match the list of APK or AAB files in the `app_path` input.
 - retry_without_sending_to_review: "false"
   opts:
     title: Retry changes without sending to review


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MINOR_ [version update](https://semver.org/)

### Context

Resolves #95 

### Changes

- Modify the `mapping_file` input to accept a `\n` or `|` separated list as well
- Parse this new input format and verify if every file path exists
- Change the multi-AAB E2E test to deploy mapping files too (see screenshot below)
- Upload each mapping file to Google Play
- Add unit tests

<!-- 
- `blahblah` is called with `hhhh` instead of `oooooo`
- `FFFFF` now returns an `error` for better error handling
- Renamed symbols in `pppppp` to increase readability
-->

![image](https://user-images.githubusercontent.com/1694986/131857357-7fccf0b6-a618-45e3-8a97-86cb13e6880e.png)


### Investigation details

Google Play API endpoint: https://developers.google.com/android-publisher/api-ref/rest/v3/edits.deobfuscationfiles/upload

The mapping file is associated with the versionCode (which should be different among the uploaded app files)

### Decisions

<!-- Please list decisions that were made for this change. -->
