### PR TITLE
Use newer signature scheme in E2E tests

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -67,6 +67,7 @@ workflows:
     - sign-apk:
         inputs:
         - android_app: $BITRISE_AAB_PATH
+        - use_apk_signer: true
     - android-build:
         title: Build wearable app
         inputs:
@@ -76,6 +77,7 @@ workflows:
     - sign-apk:
         inputs:
         - android_app: $BITRISE_AAB_PATH
+        - use_apk_signer: true
     - path::./:
         title: Execute step
         # Limit running this test to only one stack to avoid parallel testing issues

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -119,6 +119,7 @@ workflows:
     - sign-apk:
         inputs:
         - android_app: $BITRISE_AAB_PATH
+        - use_apk_signer: true
     - path::./:
         title: Execute step
         # Limit running this test to only one stack to avoid parallel testing issues
@@ -163,6 +164,7 @@ workflows:
     - sign-apk:
         inputs:
         - android_app: $BITRISE_APK_PATH_LIST
+        - use_apk_signer: true
     - path::./:
         title: Execute step
         # Limit running this test to only one stack to avoid parallel testing issues


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [X] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires NO [version update](https://semver.org/)

### Context

E2E tests are failing because our tests apps' `targetSdkVersion` is 29, but the minimum required version is 30 starting from November.

Updated the version in the sample app in https://github.com/bitrise-io/sample-apps-android-sdk22/pull/18, but the new `targetSdkVersion` also means that Google Play rejects apps signed with signature scheme v1.

### Changes

- Use `apksigner` in the signing step so that the apps are signed with a newer signature scheme (v4 probably based on `minSdkVersion` of the app)

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
