### PR TITLE
Print suggestion when API returns internal server error

### DIFF
--- a/main.go
+++ b/main.go
@@ -193,7 +193,7 @@ func main() {
 	}
 	if strings.Contains(errorString, internalServerError) {
 		log.Warnf("Google Play API responded with an unknown error")
-		log.Warnf("Suggestion: create a release manually in Google Play Console, it might reveal the real error")
+		log.Warnf("Suggestion: create a release manually in Google Play Console because the UI has the capability to present the underlying error in certain cases")
 	}
 	failf(errorString)
 }

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 )
 
 const changesNotSentForReviewMessage = "Changes cannot be sent for review automatically. Please set the query parameter changesNotSentForReview to true"
+const internalServerError = "googleapi: Error 500"
 
 func failf(format string, v ...interface{}) {
 	log.Errorf(format, v...)
@@ -189,6 +190,10 @@ func main() {
 		} else {
 			log.Warnf("Sending the edit to review failed. Please change \"Retry changes without sending to review\" input to true if you wish to send the changes with the changesNotSentForReview flag. Please note that in that case the review has to be manually initiated from Google Play Console UI")
 		}
+	}
+	if strings.Contains(errorString, internalServerError) {
+		log.Warnf("Google Play API responded with an unknown error")
+		log.Warnf("Suggestion: create a release manually in Google Play Console, it might reveal the real error")
 	}
 	failf(errorString)
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

The build sometimes fails with the following error:

```
Committing edit
Failed to commit edit, error: googleapi: Error 500: Internal error encountered., backendError
```

Based on customer feedback, this could mean multiple things, but if they go to Play Console directly and create a release manually, it tells the real root cause.

### Changes

Log a warning about the suggested workaround.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
