### PR TITLE
Migrate to shared steps-check workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,10 +1,14 @@
 format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
+include:
+- repository: steps-check
+  branch: master
+  path: steps.bitrise.yml
+
 workflows:
-  check:
-    steps:
-    - git::https://github.com/bitrise-steplib/steps-check.git: { }
+
+  # check: included from steps-check/steps.bitrise.yml
 
   e2e:
     steps:

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func (p *Publisher) uploadApplications(configs Configs, service *androidpublishe
 		}
 
 		versionCodes[versionCode]++
-		versionCodeListLog.WriteString(fmt.Sprintf("%d", versionCode))
+		fmt.Fprintf(&versionCodeListLog, "%d", versionCode)
 		if appIndex < len(appPaths)-1 {
 			versionCodeListLog.WriteString(", ")
 		}


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
No version update required (CI/infra change only).

### Context

Replace the inline `check` workflow with the shared `steps-check` workflow via an `include:` block. This keeps the CI setup consistent with other Bitrise steps and means lint/check improvements in `steps-check` are picked up automatically.

### Changes

- `bitrise.yml`: Add `include:` block pointing to `steps-check/steps.bitrise.yml` and remove the inline `check` workflow definition (now provided by the include)
- `main.go`: Fix `fmt.Sprintf` + `WriteString` → `fmt.Fprintf` as flagged by the updated golangci-lint rules in `steps-check`

### Investigation details

None.

### Decisions

The `check` workflow entry is replaced with a comment (`# check: included from steps-check/steps.bitrise.yml`) so the reader knows where to find it.